### PR TITLE
Fix "invoice-issued" event payload in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ In Event Sourcing, the state is stored in events. Events are logically grouped i
 
         "data":
         {
-            "issuedTo": "Cookie Monster",
+            "issuedBy": "Cookie Monster",
             "issuedAt": "2021-11-01T00:11:32.000Z"
         }
     },        


### PR DESCRIPTION
### Motivation

Corresponding to the typings below in the README.md, `invoice-issued` event should have **issuedBy** property, not **issuedTo** (the one from `invoice-initiated` event). Just to avoid this little confusion. 
```ts
type InvoiceIssued = Event<
  'invoice-issued',
  {
    number: string;
    issuedBy: string;
    issuedAt: Date;
  }
>;
```
