### PR TITLE
Prevent accepting mutation to closed shopping cart

### DIFF
--- a/samples/webinar/src/shoppingCarts/shoppingCart.ts
+++ b/samples/webinar/src/shoppingCarts/shoppingCart.ts
@@ -102,10 +102,7 @@ export const toShoppingCartStreamName = (shoppingCartId: string) =>
   `shopping_cart-${shoppingCartId}`;
 
 export const assertShoppingCartIsNotClosed = (shoppingCart: ShoppingCart) => {
-  if (
-    (shoppingCart.status & ShoppingCartStatus.Closed) ===
-    ShoppingCartStatus.Closed
-  ) {
+  if (shoppingCart.status !== ShoppingCartStatus.Opened) {
     throw ShoppingCartErrors.CART_IS_ALREADY_CLOSED;
   }
 };


### PR DESCRIPTION
Hello Oskar,

First of all, thanks for this very nice webinar, well explained, and working perfectly.
Having all this information condensed in a comprehensible 1h30 video is quite an achievement!

Of course, it's missing some pieces (testing for instance), but it has the benefit of getting straight to the point(s) along with discovering some features of Typescript (Partial and Readonly helpers for instance!).

While playing around with the project, I noticed that I was able to keep sending commands to a confirmed shopping cart.

After a quick and dirty check, I think the issue comes from the way you compare the shopping cart status against the enum value.

Thanks again :+1: 