### PR TITLE
Fix link in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Events:
 Read more in my articles:
 
 - 📝 [What's the difference between a command and an event?](https://event-driven.io/en/whats_the_difference_between_event_and_command/?utm_source=event_sourcing_nodejs)
-- 📝 [Events should be as small as possible, right?](https://event-driven.io/en/whats_the_difference_between_event_and_command/?utm_source=event_sourcing_nodejs)
+- 📝 [Events should be as small as possible, right?](https://event-driven.io/en/events_should_be_as_small_as_possible/?utm_source=event_sourcing_nodejs)
 
 ### What is Stream?
 


### PR DESCRIPTION
The "Events should be as small as possible, right?" link currently points to the same URL as the "What's the difference between a command and an event?" link directly above it. This fix updates the link with the correct URL.