### PR TITLE
Fix: cleanup test resources to prevent handle leaks

### DIFF
--- a/workshops/introduction_to_event_sourcing/src/03_appending_events_eventstoredb/appendingEvents.exercise.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/03_appending_events_eventstoredb/appendingEvents.exercise.test.ts
@@ -65,6 +65,10 @@ describe('Appending events', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+  
   it('should append events to EventStoreDB', async () => {
     const shoppingCartId = uuid();
     const clientId = uuid();

--- a/workshops/introduction_to_event_sourcing/src/04_getting_state_from_events_eventstoredb/immutable/gettingStateFromEvents.exercise.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/04_getting_state_from_events_eventstoredb/immutable/gettingStateFromEvents.exercise.test.ts
@@ -97,6 +97,10 @@ describe('Events definition', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+  
   it('all event types should be defined', async () => {
     const shoppingCartId = uuid();
 

--- a/workshops/introduction_to_event_sourcing/src/04_getting_state_from_events_eventstoredb/oop/gettingStateFromEvents.exercise.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/04_getting_state_from_events_eventstoredb/oop/gettingStateFromEvents.exercise.test.ts
@@ -189,6 +189,10 @@ describe('Events definition', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+  
   it('all event types should be defined', async () => {
     const shoppingCartId = uuid();
 

--- a/workshops/introduction_to_event_sourcing/src/solved/03_appending_events_eventstoredb/appendingEvents.solved.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/solved/03_appending_events_eventstoredb/appendingEvents.solved.test.ts
@@ -75,6 +75,10 @@ describe('Appending events', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+  
   it('should append events to EventStoreDB', async () => {
     const shoppingCartId = uuid();
     const clientId = uuid();

--- a/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/immutable/solution1/gettingStateFromEvents.solved.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/immutable/solution1/gettingStateFromEvents.solved.test.ts
@@ -247,6 +247,10 @@ describe('Events definition', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+  
   it('all event types should be defined', async () => {
     const shoppingCartId = uuid();
 

--- a/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/immutable/solution2/gettingStateFromEvents.solved.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/immutable/solution2/gettingStateFromEvents.solved.test.ts
@@ -357,6 +357,10 @@ describe('Events definition', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+
   it('all event types should be defined', async () => {
     const shoppingCartId = uuid();
 

--- a/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/immutable/solution3/gettingStateFromEvents.solved.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/immutable/solution3/gettingStateFromEvents.solved.test.ts
@@ -247,6 +247,10 @@ describe('Events definition', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+  
   it('all event types should be defined', async () => {
     const shoppingCartId = uuid();
 

--- a/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/oop/solution1/gettingStateFromEvents.solved.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/oop/solution1/gettingStateFromEvents.solved.test.ts
@@ -245,6 +245,10 @@ describe('Events definition', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+  
   it('all event types should be defined', async () => {
     const shoppingCartId = uuid();
 

--- a/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/oop/solution2/gettingStateFromEvents.solved.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/oop/solution2/gettingStateFromEvents.solved.test.ts
@@ -354,6 +354,10 @@ describe('Events definition', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+  
   it('all event types should be defined', async () => {
     const shoppingCartId = uuid();
 

--- a/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/oop/solution3/gettingStateFromEvents.solved.test.ts
+++ b/workshops/introduction_to_event_sourcing/src/solved/04_getting_state_from_events_eventstoredb/oop/solution3/gettingStateFromEvents.solved.test.ts
@@ -286,6 +286,10 @@ describe('Events definition', () => {
     eventStore = await getEventStoreDBTestClient();
   });
 
+  afterAll(async () => {
+    await eventStore.dispose();
+  })
+  
   it('all event types should be defined', async () => {
     const shoppingCartId = uuid();
 


### PR DESCRIPTION
This PR fixes an issue where test processes were being force-terminated due to unclosed database resource. The changes ensure proper cleanup and disposal of database during test teardown.

Changes:
- Added proper database connection cleanup in afterAll hooks
- Ensured database resources are properly terminated after test completion