### PR TITLE
Removed TestContainers as a default integration test engine

### DIFF
--- a/workshops/introduction_to_event_sourcing/README.md
+++ b/workshops/introduction_to_event_sourcing/README.md
@@ -62,13 +62,7 @@ Follow the instructions in exercises folders.
 
 ## Running
 
-1. Tests by default are using TestContainers, but if you'd like to troubleshoot it manually, you can disable the TestContainers and use regular docker images by setting the `ES_USE_TEST_CONTAINERS` environment variable to false:
-
-```bash
-ES_USE_TEST_CONTAINERS=false
-```
-
-2. Then run: `docker compose up` to start EventStoreDB docker image.You should automatically get:
+1. Run: `docker compose up` to start EventStoreDB docker image.You should automatically get:
 
 - EventStoreDB UI: http://localhost:2113/
 - Mongo Express UI: http://localhost:8081/

--- a/workshops/introduction_to_event_sourcing/src/core/testing/eventStoreDB/index.ts
+++ b/workshops/introduction_to_event_sourcing/src/core/testing/eventStoreDB/index.ts
@@ -8,11 +8,11 @@ let esdbContainer: StartedEventStoreDBContainer | undefined;
 let instanceCounter = 0;
 
 export const getEventStoreDBTestClient = async (
-  useTestContainers = true,
+  useTestContainers = false,
 ): Promise<EventStoreDBClient> => {
   let connectionString;
 
-  if (process.env.ES_USE_TEST_CONTAINERS !== 'false' && useTestContainers) {
+  if (process.env.ES_USE_TEST_CONTAINERS === 'false' && useTestContainers) {
     ++instanceCounter;
     if (!esdbContainer)
       esdbContainer = await new EventStoreDBContainer().start();

--- a/workshops/introduction_to_event_sourcing/src/core/testing/mongoDB/index.ts
+++ b/workshops/introduction_to_event_sourcing/src/core/testing/mongoDB/index.ts
@@ -8,11 +8,11 @@ let mongoDBContainer: StartedMongoDBContainer | undefined;
 let instanceCounter = 0;
 
 export const getMongoDBTestClient = async (
-  useTestContainers = true,
+  useTestContainers = false,
 ): Promise<MongoClient> => {
   let connectionString;
 
-  if (process.env.ES_USE_TEST_CONTAINERS !== 'false' && useTestContainers) {
+  if (process.env.ES_USE_TEST_CONTAINERS === 'false' && useTestContainers) {
     ++instanceCounter;
     if (!mongoDBContainer)
       mongoDBContainer = await new MongoDBContainer().start();

--- a/workshops/introduction_to_event_sourcing/src/core/testing/postgreSQL/index.ts
+++ b/workshops/introduction_to_event_sourcing/src/core/testing/postgreSQL/index.ts
@@ -7,11 +7,11 @@ let postgreSQLContainer: StartedPostgreSqlContainer | undefined;
 let instanceCounter = 0;
 
 export const getPostgreSQLConnectionString = async (
-  useTestContainers = true,
+  useTestContainers = false,
 ): Promise<string> => {
   let connectionString;
 
-  if (process.env.ES_USE_TEST_CONTAINERS !== 'false' && useTestContainers) {
+  if (process.env.ES_USE_TEST_CONTAINERS === 'false' && useTestContainers) {
     ++instanceCounter;
     if (!postgreSQLContainer)
       postgreSQLContainer = await new PostgreSqlContainer().start();

--- a/workshops/introduction_to_event_sourcing/src/solved/04_appending_events_emmett/README.md
+++ b/workshops/introduction_to_event_sourcing/src/solved/04_appending_events_emmett/README.md
@@ -8,13 +8,7 @@ Using a defined structure of events from the [first exercise](../01_events_defin
 
 ## Prerequisities
 
-1. Tests by default are using TestContainers, but if you'd like to troubleshoot it manually, you can disable the TestContainers and use regular docker images by setting the `ES_USE_TEST_CONTAINERS` environment variable to false:
-
-```bash
-ES_USE_TEST_CONTAINERS=false
-```
-
-2. Then run: `docker compose up` (or for Mac `docker compose -f docker-compose.arm.yml up`) to start EventStoreDB docker image.You should automatically get:
+1. Run: `docker compose up` (or for Mac `docker compose -f docker-compose.arm.yml up`) to start EventStoreDB docker image.You should automatically get:
 
 - EventStoreDB UI: http://localhost:2113/
 - Mongo Express UI: http://localhost:8081/


### PR DESCRIPTION
For educational reasons, it's better to be able to see data in the event store. Plus TestContainers are slow...